### PR TITLE
Add config support and factor out modification for experiment

### DIFF
--- a/configs/moe_t5_base_race_lora_train.yaml
+++ b/configs/moe_t5_base_race_lora_train.yaml
@@ -1,0 +1,25 @@
+exp_name: moe-t5-base-race-lora
+
+model:
+  t5_variant: t5-base
+  learning_rate: 1e-4
+  lr_scheduler: Constant
+
+  model_modifier_config:
+    base_model_type: moe
+    k: 20
+    moe_params_path: results/t5-base/race/param_split
+
+    tuning_type: lora
+    lora_rank: 32
+
+    ckpt_path: lightning_logs/T5BaseFinetuneRACE/2024-03-02-19:16:12/checkpoints/T5BaseFinetuneRACE-global_step=0-epoch=02-step=64000-ckpt_metric=0.715.ckpt
+
+data:
+  dataset: race
+  batch_size: 4
+  max_source_length: 1536
+
+trainer:
+  max_epochs: 3
+  val_check_interval: 2000

--- a/configs/t5_base_race_fft_train.yaml
+++ b/configs/t5_base_race_fft_train.yaml
@@ -1,0 +1,20 @@
+exp_name: T5BaseFinetuneRACE
+
+model:
+  t5_variant: t5-base
+  learning_rate: 1e-4
+  lr_scheduler: Constant
+
+  model_modifier_config:
+    base_model_type: unmodified
+    tuning_type: fft
+    ckpt_path: null
+
+data:
+  dataset: race
+  batch_size: 4
+  max_source_length: 1536
+
+trainer:
+  max_epochs: 3
+  val_check_interval: 2000

--- a/configs/t5_base_sst2_lora_train.yaml
+++ b/configs/t5_base_sst2_lora_train.yaml
@@ -1,0 +1,21 @@
+exp_name: t5-sst-lora
+
+model:
+  t5_variant: t5-base
+  learning_rate: 1e-5
+  lr_scheduler: Constant
+
+  model_modifier_config:
+    base_model_type: unmodified
+    tuning_type: lora
+    ckpt_path: null
+    lora_rank: 32
+
+data:
+  dataset: sst2
+  batch_size: 64
+  max_source_length: 512
+
+trainer:
+  max_epochs: 1
+  val_check_interval: 200

--- a/model_modifier.py
+++ b/model_modifier.py
@@ -1,0 +1,160 @@
+import os
+import types
+
+import numpy as np
+import torch
+from transformers.models.t5.modeling_t5 import T5LayerFF, T5DenseActDense
+
+from moe_lora import LoRALinearLayer, LoRADenseActDenseLayer
+from utils.utils import LoadCheckpoint
+
+
+class ModifierBase():
+  """Base class for modifying the t5 model"""
+  def __init__(self, ckpt_path=None, **kwargs):
+    self.ckpt_path = ckpt_path
+
+  
+  def __call__(self, model):
+    if self.ckpt_path:
+      print(f'Loading Checkpoint {self.ckpt_path}')
+      LoadCheckpoint(model, self.ckpt_path)
+
+
+class MoEModifier(ModifierBase):
+  "MoE-fy the t5 model."
+  def __init__(self, moe_params_path, k, **kwargs):
+    super().__init__(**kwargs)
+    self.moe_params_path = moe_params_path
+    self.k = k
+
+  def __call__(self, model):
+    super().__call__(model)
+
+    def _forward(ffn_self, hidden_states):
+        bsz, seq_len, hidden_size = hidden_states.shape
+        hidden_states_mlp = hidden_states
+        hidden_states_mlp = hidden_states_mlp.view(-1, hidden_size)
+
+        hidden_states_mlp = hidden_states_mlp / torch.norm(hidden_states_mlp, dim=-1).unsqueeze(-1)
+        score = ffn_self.mlp(hidden_states_mlp)
+
+        labels = torch.topk(score, k=self.k, dim=-1)[1].view(bsz, seq_len, self.k)
+        cur_mask = torch.nn.functional.embedding(labels, ffn_self.patterns).sum(-2)
+
+        hidden_states = ffn_self.wi(hidden_states)
+        hidden_states = ffn_self.act(hidden_states)
+
+        cur_mask = cur_mask.float()
+        hidden_states = hidden_states * cur_mask
+
+        hidden_states = ffn_self.dropout(hidden_states)
+        hidden_states = ffn_self.wo(hidden_states)
+
+        return hidden_states
+
+    def modify_ffn(ffn, path):
+        assert type(ffn) == T5DenseActDense
+        labels = torch.load(path)
+        cluster_num = max(labels)+1
+
+        patterns = []
+        for i in range(cluster_num):
+            patterns.append(np.array(labels) == i)
+        ffn.patterns = torch.Tensor(np.array(patterns)).cuda()
+        ffn.k = self.k
+        ffn.mlp = torch.load(path+'_input_compl').cuda()
+        ffn.forward_old = ffn.forward
+        ffn.forward = types.MethodType(_forward, ffn)
+
+    # encoder
+    for layer_idx, layer in enumerate(model.encoder.block):
+        ffn = layer.layer[1].DenseReluDense
+        path = os.path.join(self.moe_params_path, 'encoder.block.{}.layer.1.DenseReluDense.wi.weight'.format(layer_idx))
+        modify_ffn(ffn, path)
+
+    #decoder
+    for layer_idx, layer in enumerate(model.decoder.block):
+        ffn = layer.layer[2].DenseReluDense
+        path = os.path.join(self.moe_params_path, 'decoder.block.{}.layer.2.DenseReluDense.wi.weight'.format(layer_idx))
+        modify_ffn(ffn, path)
+
+
+def replace_linear_with_lora_linear(ffn, lora_rank, useBias=False):
+    if hasattr(ffn, 'wi'):
+        original_weight = ffn.wi.weight.data
+        lora_layer = LoRALinearLayer(original_weight, lora_rank, useBias=useBias).cuda()
+        ffn.wi = lora_layer
+
+    if hasattr(ffn, 'wo'):
+        original_weight = ffn.wo.weight.data
+        lora_layer = LoRALinearLayer(original_weight, lora_rank, useBias=useBias).cuda()
+        ffn.wo = lora_layer
+    return ffn
+
+
+def dfs_dense_relu_dense(model, leaf_callback, **kwargs):
+  """Traverse through the model tree and call leaf_callback on DenseReluDense."""
+  for _, module in model.named_children():
+    if isinstance(module, T5LayerFF):
+      dense_relu_dense = module.DenseReluDense
+      module.DenseReluDense = leaf_callback(dense_relu_dense, **kwargs)
+    else:
+      # Recursively apply this function to child modules
+      dfs_dense_relu_dense(module, leaf_callback, **kwargs)
+
+
+class SFTBase():
+  def __init__(self, modifier=None, **kwargs):
+    self.modifier = modifier
+
+  def __call__(self, model):
+    if self.modifier:
+      self.modifier(model)
+
+    opt_params_patterns = [r'.*']
+    return opt_params_patterns
+
+
+class AddLoRA(SFTBase):
+  def __init__(self, lora_rank, **kwargs):
+    super().__init__(**kwargs)
+    self.lora_rank = lora_rank
+
+  def __call__(self, model):
+    super().__call__(model)
+    dfs_dense_relu_dense(model, replace_linear_with_lora_linear, self.lora_rank, useBias=False)
+    opt_params_patterns = [r'.*\.A', r'.*\.B']
+    return opt_params_patterns
+
+
+class AddDenseActDenseLoRA(SFTBase):
+  def __init__(self, lora_rank, **kwargs):
+    super().__init__(**kwargs)
+    self.lora_rank = lora_rank
+
+  def __call__(self, model):
+    super().__call__(model)
+
+    def _replace_with_lora(dense_act_dense, lora_rank):
+      assert isinstance(dense_act_dense, T5DenseActDense)
+      return LoRADenseActDenseLayer(dense_act_dense, lora_rank)
+
+    dfs_dense_relu_dense(model, _replace_with_lora, self.lora_rank)
+
+
+def get_model_modifier(base_model_type,
+                       tuning_type, **kwargs):
+  # Convert the model to a MoE if needed
+  if base_model_type == 'unmodified':
+    modifier = ModifierBase(**kwargs)
+  elif base_model_type == 'moe':
+    modifier = MoEModifier(**kwargs)
+
+  # Do either LoRA or Full Finetuning
+  if tuning_type in ('full', 'fft'):
+    return SFTBase(modifier=modifier, **kwargs)
+  elif tuning_type == 'lora':
+    return AddLoRA(modifier=modifier, **kwargs)
+  elif tuning_type == 'dense_act_dense_lora':
+    return AddDenseActDenseLoRA(modifier=modifier, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ datasets
 k-means-constrained
 lightning
 numpy
+omegaconf
 sentencepiece
 scikit-learn
 scipy

--- a/t5_train_main.py
+++ b/t5_train_main.py
@@ -1,0 +1,199 @@
+import argparse
+import datetime
+import os
+import re
+
+from multiprocessing import cpu_count
+
+import lightning as L
+import torch
+import torch.nn.functional as F
+import torchmetrics
+import transformers
+import utils
+
+import model_modifier
+from omegaconf import OmegaConf
+from transformers import T5Tokenizer, T5ForConditionalGeneration
+
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('--config', type=str, default='configs/moe_t5_base_race_lora_train.yaml', help='path to the config file for training')
+
+
+class LitT5(L.LightningModule):
+  def __init__(self, t5_variant, output_classes, learning_rate, model_modifier_config,
+               weight_decay=0, lr_scheduler='Constant', max_source_length=512):
+    super().__init__()
+    model = T5ForConditionalGeneration.from_pretrained(t5_variant)
+    # modifier will do the modifications for our experiments. e.g. moe-fy the model, adding lora, etc.
+    modifier = model_modifier.get_model_modifier(**model_modifier_config)
+    self.opt_params_patterns = modifier(model)
+    self.model = model
+    self.tokenizer = T5Tokenizer.from_pretrained(t5_variant, model_max_length=max_source_length)
+
+    self.output_classes = output_classes
+    self.output_class_tokens = utils.dataset_loader.get_output_class_tokens(self.tokenizer, output_classes)
+
+    self.loss_metric = torchmetrics.aggregation.MeanMetric()
+    self.accuracy_metric = torchmetrics.classification.Accuracy(task='multiclass', num_classes=len(self.output_classes))
+
+    self.lr_scheduler = lr_scheduler
+    self.learning_rate = learning_rate
+    self.weight_decay = weight_decay
+
+    self.save_hyperparameters()
+
+  def configure_optimizers(self):
+    lora_weights = []
+    for name, param in self.named_parameters():
+      for pattern in self.opt_params_patterns:
+        if re.match(pattern, name):
+          print(f' Adding {name} to list of weights to be optimized')
+          lora_weights.append(param)
+
+    optimizer = torch.optim.AdamW(
+      lora_weights, lr=self.learning_rate, weight_decay=self.weight_decay)
+    if self.lr_scheduler == 'Constant':
+      lr_scheduler = transformers.get_constant_schedule(optimizer)
+    elif self.lr_scheduler == 'ReduceLROnPlateau':
+      lr_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, mode='min')
+    else:
+      raise NotImplementedError(f'Unimplemented lr scheduler {self.lr_scheduler}')
+
+    lr_scheduler_config = {
+      'scheduler': lr_scheduler,
+      'interval': 'step',
+      'monitor': 'Metrics/logits',
+      'strict': False,
+    }
+    return {
+      'optimizer': optimizer,
+      'lr_scheduler': lr_scheduler_config
+    }
+
+  def forward(self, x):
+    input_ids = self.tokenizer(
+      text=[x['sentence']], return_tensors="pt").input_ids.to(self.device)
+    dec_input_ids = torch.tensor([self.tokenizer.pad_token_id]).to(self.device)
+    output = self.model(input_ids=input_ids, decoder_input_ids=dec_input_ids)
+    return output
+
+  def _load_one_batch(self, batch):
+    labels = batch["label"].to(self.device)
+    tokenized = self.tokenizer(
+      text=batch["sentence"], return_tensors="pt", padding=True)
+    input_ids = tokenized.input_ids.to(self.device)
+    attention_mask = tokenized.attention_mask.to(self.device)
+    dec_input_ids = torch.tensor(len(labels) * [[self.tokenizer.pad_token_id]]).to(self.device)
+    return input_ids, attention_mask, dec_input_ids, labels
+
+  def training_step(self, batch, batch_idx):
+    input_ids, attention_mask, dec_input_ids, labels = self._load_one_batch(batch)
+
+    output = self.model(input_ids=input_ids, attention_mask=attention_mask,
+                        labels=dec_input_ids)
+    logits = output.logits.squeeze(dim=1)[:, self.output_class_tokens]
+    loss = F.cross_entropy(logits, labels)
+
+    self.loggers[0].log_metrics(
+      {'loss': loss},
+      self.global_step
+    )
+
+    return loss
+
+  def validation_step(self, batch, batch_idx):
+    input_ids, attention_mask, dec_input_ids, labels = self._load_one_batch(batch)
+
+    output = self.model(input_ids=input_ids, attention_mask=attention_mask,
+                        labels=dec_input_ids)
+    logits = output.logits.squeeze(dim=1)[:, self.output_class_tokens]
+    preds = torch.argmax(logits, 1)
+
+    logits_loss = F.cross_entropy(logits, labels)
+    accuracy = (preds == labels).float().mean()
+
+    # Setting logger to False
+    self.log('ckpt_metric', accuracy, batch_size=labels.size(0), logger=False)
+
+    self.accuracy_metric(preds=logits, target=labels)
+    self.loss_metric.update(logits_loss)
+
+    return logits_loss
+
+  def on_validation_epoch_end(self):
+    accuracy = self.accuracy_metric.compute()
+    loss = self.loss_metric.compute()
+    self.loggers[1].log_metrics(
+      {
+        'loss': loss,
+        'Metrics/accuracy': accuracy,
+        'Metrics/logits': loss,
+      },
+      self.global_step
+    )
+    self.accuracy_metric.reset()
+    self.loss_metric.reset()
+
+
+def main():
+  args = parser.parse_args()
+  configs = OmegaConf.load(args.config)
+
+  # Dataset
+  train_set, valid_set, output_classes = utils.dataset_loader.load_dataset(configs.data.dataset)
+
+  # Model
+  model = LitT5(t5_variant=configs.model.t5_variant, output_classes=output_classes,
+                learning_rate=configs.model.learning_rate,
+                lr_scheduler=configs.model.lr_scheduler,
+                model_modifier_config=configs.model.model_modifier_config,
+                max_source_length=configs.data.max_source_length)
+
+  num_data_workers = max(cpu_count()//2, 1)
+  train_loader = torch.utils.data.DataLoader(
+    train_set, batch_size=configs.data.batch_size, shuffle=True,
+    num_workers=num_data_workers
+  )
+  valid_loader = torch.utils.data.DataLoader(
+    valid_set, batch_size=configs.data.batch_size, shuffle=False,
+    num_workers=num_data_workers
+  )
+
+  curr_time = datetime.datetime.now().strftime('%Y-%m-%d-%H:%M:%S')
+
+  # saves top-K checkpoints based on validation accuracy
+  checkpoint_callback = L.pytorch.callbacks.ModelCheckpoint(
+    save_last=True, every_n_train_steps=configs.trainer.val_check_interval,
+    save_top_k=3, monitor='ckpt_metric', mode='max',
+    dirpath=os.path.join('lightning_logs', configs.exp_name, curr_time, 'checkpoints'),
+    filename=configs.exp_name+'-{global_step}-{epoch:02d}-{step}-{ckpt_metric:.3f}'
+  )
+
+  # Log to train and valid sub-directory
+  train_logger = L.pytorch.loggers.TensorBoardLogger(
+    "lightning_logs", name=configs.exp_name, version=curr_time, sub_dir="train")
+  valid_logger = L.pytorch.loggers.TensorBoardLogger(
+    "lightning_logs", name=configs.exp_name, version=curr_time, sub_dir="valid")
+  loggers = [train_logger, valid_logger]
+
+  # Log learning rate
+  lr_monitor = L.pytorch.callbacks.LearningRateMonitor(
+    logging_interval='step', log_momentum=True
+  )
+
+  # Train
+  trainer = L.Trainer(default_root_dir=configs.exp_name, num_sanity_val_steps=-1,
+                      max_epochs=configs.trainer.max_epochs,
+                      val_check_interval=configs.trainer.val_check_interval,
+                      logger=loggers, callbacks=[checkpoint_callback, lr_monitor])
+  trainer.fit(model=model, train_dataloaders=train_loader, val_dataloaders=valid_loader)
+
+  print(checkpoint_callback.best_model_path)
+
+
+if __name__ == "__main__":
+  main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,4 @@
 name = "utils"
 
-from . import utils
 from . import dataset_loader
+from . import utils

--- a/utils/dataset_loader.py
+++ b/utils/dataset_loader.py
@@ -9,7 +9,7 @@ def _tokenize_example(example, tokenizer):
     text=example["sentence"], return_tensors="pt", padding=True)
   example['input_ids'] = example['tokenized_input'].input_ids
   example['attention_mask'] = example['tokenized_input'].attention_mask
-  
+
 
 def _process_sst2_sentence(example, tokenizer=None):
   example['sentence'] = f"sst2 sentence: {example['sentence']}"
@@ -58,7 +58,7 @@ def load_dataset(dataset_name, tokenizer=None):
 
   return train, valid, output_classes
 
-  
+
 def get_output_class_tokens(tokenizer, output_classes):
     num_classes = len(output_classes)
     output_class_tokens = tokenizer(output_classes, return_tensors='pt').input_ids


### PR DESCRIPTION
A couple big changes:
 * The main training script is now moved to `t5_train_main.py`
 * The script uses OmegaConf to parse in the configs under `configs/*` to run the experiment. This helps with tracking the experiments for a bit.
 * The model-specific changes are now controlled by `model_modifiers.py`. It takes a two stage approach: it first either moe-fies the model or leave it as is, then it either adds lora or returns all parameters for fine-tuning.